### PR TITLE
feat: add `CommonSettings::ExtFlags` enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.5
+- Add `CommonSettings::ExtFlags` enumeration
+
 ## 0.3.4
 - Bugfix accessory address encoding still wrong ([#17](https://github.com/ZIMO-Elektronik/Z21/issues/17))
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ This library is meant to be consumed with CMake,
 
 ```cmake
 # Either by including it with CPM
-cpmaddpackage("gh:ZIMO-Elektronik/Z21@0.3.4")
+cpmaddpackage("gh:ZIMO-Elektronik/Z21@0.3.5")
 
 # or the FetchContent module
 FetchContent_Declare(
   DCC
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/Z21"
-  GIT_TAG v0.3.4)
+  GIT_TAG v0.3.5)
 
 target_link_libraries(YourTarget PRIVATE Z21::Z21)
 ```
@@ -82,7 +82,7 @@ or, on [ESP32 platforms](https://www.espressif.com/en/products/socs/esp32), with
 ```yaml
 dependencies:
   zimo-elektronik/z21:
-    version: "0.3.4"
+    version: "0.3.5"
 ```
 
 ### Build
@@ -102,7 +102,7 @@ The simulator allows you to try out the library directly in a simple GUI. The ap
 On [ESP32 platforms](https://www.espressif.com/en/products/socs/esp32) examples from the [examples](https://github.com/ZIMO-Elektronik/DCC/raw/master/examples) subfolder can be built directly using the [IDF Frontend](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-py.html).
 
 ```sh
-idf.py create-project-from-example "zimo-elektronik/z21^0.3.4:esp32"
+idf.py create-project-from-example "zimo-elektronik/z21^0.3.5:esp32"
 ```
 
 ## Usage

--- a/examples/sim/settings.cpp
+++ b/examples/sim/settings.cpp
@@ -39,7 +39,7 @@ Settings::Settings(QWidget* parent) : QWidget{parent} {
     grid->addWidget(new QLabel{"Ext disable turnout timeout"}, row, 0);
     grid->addWidget(
       _common.ext_flags.disable_turnout_timeout_checkbox, row++, 2);
-    grid->addWidget(new QLabel{"Ext auto deactivate turnout output"}, row, 0);
+    grid->addWidget(new QLabel{"Ext disable turnout auto deactivate"}, row, 0);
     grid->addWidget(
       _common.ext_flags.disable_turnout_auto_deact_checkbox, row++, 2);
     grid->addWidget(new QLabel{"Ext RCN-213 turnout addressing"}, row, 0);
@@ -337,7 +337,7 @@ void Settings::initCommonWidgets() {
     _common.loconet_mode_combobox->setCurrentIndex(value.toInt());
   else _common.loconet_mode_combobox->setCurrentIndex(3);
   if (auto const value{config.value("settings_ext_flags")}; value.isValid())
-    commonExtFlags(static_cast<uint8_t>(value.toUInt()));
+    commonExtFlags(static_cast<z21::CommonSettings::ExtFlags>(value.toUInt()));
   if (auto const value{config.value("settings_purging_time")}; value.isValid())
     _common.purging_time_combobox->setCurrentIndex(value.toInt());
   if (auto const value{config.value("settings_bus_flags")}; value.isValid())
@@ -476,51 +476,56 @@ void Settings::initMmDccWidgets() {
 }
 
 //
-void Settings::commonExtFlags(uint8_t flags) {
+void Settings::commonExtFlags(z21::CommonSettings::ExtFlags flags) {
   //
   _common.ext_flags.disable_turnout_timeout_checkbox->setChecked(
-    static_cast<bool>(flags & 0x01u));
+    static_cast<bool>(flags &
+                      z21::CommonSettings::ExtFlags::TurnoutTimeoutDisable));
 
   //
   _common.ext_flags.disable_turnout_auto_deact_checkbox->setChecked(
-    static_cast<bool>(flags & 0x02u));
+    static_cast<bool>(flags &
+                      z21::CommonSettings::ExtFlags::TurnoutAutoDeactDisable));
 
   //
   _common.ext_flags.accessory_start_group1_checkbox->setChecked(
-    static_cast<bool>(flags & 0x04u));
+    static_cast<bool>(flags &
+                      z21::CommonSettings::ExtFlags::AccessoryStartGroup1));
 
   //
   _common.ext_flags.rbus_as_xbus2_checkbox->setChecked(
-    static_cast<bool>(flags & 0x20u));
+    static_cast<bool>(flags & z21::CommonSettings::ExtFlags::RBusAsXBus2));
 
   //
   _common.ext_flags.invert_accessory_red_green_checkbox->setChecked(
-    static_cast<bool>(flags & 0x40u));
+    static_cast<bool>(flags &
+                      z21::CommonSettings::ExtFlags::AccessoryInvRedGreen));
 }
 
-uint8_t Settings::commonExtFlags() const {
+z21::CommonSettings::ExtFlags Settings::commonExtFlags() const {
   uint8_t retval{};
 
   //
   if (_common.ext_flags.disable_turnout_timeout_checkbox->isChecked())
-    retval |= 0x01u;
+    retval |= z21::CommonSettings::ExtFlags::TurnoutTimeoutDisable;
 
   //
   if (_common.ext_flags.disable_turnout_auto_deact_checkbox->isChecked())
-    retval |= 0x02u;
+    retval |= z21::CommonSettings::ExtFlags::TurnoutAutoDeactDisable;
 
   //
   if (_common.ext_flags.accessory_start_group1_checkbox->isChecked())
-    retval |= 0x04u;
+    retval |= z21::CommonSettings::ExtFlags::AccessoryStartGroup1;
 
   //
-  if (_common.ext_flags.rbus_as_xbus2_checkbox->isChecked()) retval |= 0x20u;
+  if (_common.ext_flags.rbus_as_xbus2_checkbox->isChecked())
+    retval |= z21::CommonSettings::ExtFlags::RBusAsXBus2;
 
   //
   if (_common.ext_flags.invert_accessory_red_green_checkbox->isChecked())
-    retval |= 0x40u;
+    retval |= z21::CommonSettings::ExtFlags::AccessoryInvRedGreen;
 
-  return retval;
+  return static_cast<z21::CommonSettings::ExtFlags>(retval);
 }
 
 //

--- a/examples/sim/settings.hpp
+++ b/examples/sim/settings.hpp
@@ -25,8 +25,8 @@ private:
   void initCommonWidgets();
   void initMmDccWidgets();
 
-  void commonExtFlags(uint8_t flags);
-  uint8_t commonExtFlags() const;
+  void commonExtFlags(z21::CommonSettings::ExtFlags flags);
+  z21::CommonSettings::ExtFlags commonExtFlags() const;
 
   void commonBusFlags(uint8_t flags);
   uint8_t commonBusFlags() const;

--- a/include/z21/common_settings.hpp
+++ b/include/z21/common_settings.hpp
@@ -50,7 +50,15 @@ struct CommonSettings {
   uint8_t loconet_mode{};
 
   ///
-  uint8_t ext_settings{};
+  enum ExtFlags : uint8_t {
+    TurnoutTimeoutDisable = 0x01u,
+    TurnoutAutoDeactDisable = 0x02u,
+    AccessoryStartGroup1 = 0x04u,
+    DccSnifferPassive = 0x08u,
+    DccSnifferSpeedStep28 = 0x10u,
+    RBusAsXBus2 = 0x20u,
+    AccessoryInvRedGreen = 0x40u,
+  } ext_settings{};
 
   ///
   uint8_t purging_time{};

--- a/include/z21/server/base.hpp
+++ b/include/z21/server/base.hpp
@@ -1413,7 +1413,8 @@ private:
                 .enable_loconet_current_source = static_cast<bool>(chunk[4uz]),
                 .loconet_fast_clock_rate = chunk[5uz],
                 .loconet_mode = chunk[6uz],
-                .ext_settings = chunk[7uz],
+                .ext_settings =
+                  static_cast<CommonSettings::ExtFlags>(chunk[7uz]),
                 .purging_time = chunk[8uz],
                 .bus_settings = chunk[9uz]});
           break;


### PR DESCRIPTION
Also just realized that the 0x02 ExtSetting works different than I expected.
Before I thought it automatically disables the complementary output upon receiving an enable command, so e.g.
- P0 on, also send P1 off
- P1 on, also send P0 off

But that's only half of the it I think. I think it basically defers switching off the complementary output to a new enable command, instead of switching off after some time...